### PR TITLE
[MAX-MAT-001] Strip buggy specular_rotation=0.25 from MaterialX export

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,11 @@
 ## Changelog
 
 
+### Unreleased (Miris fork)
+
+#### Fixes:
+- [MAX-MAT-001] MaterialX export: strip the spurious `specular_rotation = 0.25` default that 3ds Max's `MtlxIOUtil` bridge writes on every `ND_standard_surface_surfaceshader`. The MaterialX nodedef default is 0.0, and the value has no visual effect when `specular_anisotropy` is zero; the spurious value is preserved by `MtlxShaderWriter` only when anisotropy is provably non-zero. See `doc/translation-mapping.md`.
+
 ### v0.15.0
 
 #### What's New:

--- a/doc/translation-mapping.md
+++ b/doc/translation-mapping.md
@@ -1,0 +1,118 @@
+# 3ds Max → MaterialX / USD translation mapping
+
+This document tracks how 3ds Max PhysicalMaterial / OpenPBR / MaterialXMaterial
+properties translate to MaterialX `standard_surface` (and related) shader
+inputs as they are written through the Miris fork's USD exporter
+(`src/translators/MtlxShaderWriter.cpp`).
+
+Generated and maintained by the Improvement Agent. Each entry corresponds to
+a PR that:
+
+1. Updates the relevant row of the **Status** table below.
+2. Lands a C++ change in the writer (almost always
+   `MtlxShaderWriter.cpp` for surface-shader mappings).
+3. Lands a validator script (Python, runnable under `hython`) that proves the
+   logic against the captured corpus in `samples/complex_export.usda` (or a
+   synthetic fixture) without requiring a Windows build.
+4. Where the bite is a *workaround for an upstream 3ds Max bug*, it
+   documents which 3ds Max version(s) the workaround targets and what
+   condition retires it.
+
+## Translation model — what the writer can actually change
+
+`MtlxShaderWriter.cpp` is mostly a **passthrough**: it asks 3ds Max for a
+MaterialX XML string via the MaxScript bridge `MtlxIOUtil.ExportMtlxString`,
+parses it, and walks the resulting `MaterialX::Document` to create USD
+shader prims. The MaxScript bridge lives inside 3ds Max itself and cannot be
+modified from this plugin.
+
+The C++ writer therefore has two intervention points:
+
+1. **Pre-passthrough** (impossible — the MaxScript bridge has already
+   serialized whatever it serialized).
+2. **Post-parse, pre-USD-author** — after `readFromXmlString`, the
+   in-memory MaterialX document can be normalized before any USD prims are
+   created. This is where workarounds for buggy 3ds Max defaults live.
+
+Status legend:
+
+* **direct pairing** — a 1:1 mapping between a 3ds Max source property and a
+  MaterialX node/input that the upstream bridge already emits correctly. No
+  C++ intervention required.
+* **approximating workaround** — the writer mutates the MaterialX document
+  to compose a `standard_surface`-compatible result that approximates a 3ds
+  Max feature the bridge does not faithfully translate.
+* **bug normalization** — the writer strips or rewrites a value that the
+  upstream bridge emits incorrectly (hardcoded default, off-by-one, wrong
+  unit, etc.) so the resulting USD matches what a correctly-implemented
+  exporter should produce.
+* **no equivalent** — the source property has no MaterialX representation;
+  the writer emits a `TF_WARN` so the divergence is observable.
+
+## Status
+
+| Source (3ds Max) | MaterialX target | Kind | Affects MaterialX nodedef | Workaround triggers when | PR | Date |
+| --- | --- | --- | --- | --- | --- | --- |
+| PhysicalMaterial.anisotropy_angle | `standard_surface.specular_rotation` | bug normalization | `ND_standard_surface_surfaceshader` | Bridge emits `0.25` AND `specular_anisotropy` is static-zero or absent | (this PR) | 2026-06-20 |
+
+## Notes per expression
+
+### PhysicalMaterial.anisotropy_angle → standard_surface.specular_rotation  (MAX-MAT-001)
+
+**Symptom.** The 3ds Max-shipped `MtlxIOUtil.ExportMtlxString` MaxScript
+bridge always emits `<input name="specular_rotation" type="float"
+value="0.25" />` on every `ND_standard_surface_surfaceshader`, regardless of
+whether the source PhysicalMaterial has any anisotropy authored. Six out of
+six materials in the diagnostic corpus exhibit this. The MaterialX
+`standard_surface` nodedef defaults `specular_rotation` to **0.0**.
+
+**Why it matters.** `specular_rotation` is multiplied by
+`specular_anisotropy` inside the standard_surface BSDF, so the buggy value
+has no observable lighting effect in the (universal) `anisotropy == 0`
+case. It *does* matter for any downstream layer that turns anisotropy on,
+or for tools that read MaterialX values directly for content authoring or
+roundtripping. The wrong value silently introduces a 0.25-turns (90°)
+highlight rotation the source DCC never asked for.
+
+**Fix.** Add a post-parse normalization pass in `MtlxShaderWriter::Write()`
+that walks the parsed `MaterialX::Document`, looks for `standard_surface`
+nodes carrying `specular_rotation = 0.25` AND no anisotropy (absent or
+static 0), and removes the `specular_rotation` input. After normalization
+the input falls back to the nodedef default (`0.0`).
+
+**Bounds (where the fix conservatively does nothing):**
+
+* `specular_rotation` is connected to a node or nodegraph — could carry an
+  intentional procedural rotation; keep it.
+* `specular_rotation` has any static value other than `0.25` — the user
+  authored it explicitly; keep it.
+* `specular_anisotropy` is connected — runtime value unknown; assume the
+  rotation may be intentional and keep it.
+* `specular_anisotropy` is statically non-zero — anisotropy is on, rotation
+  matters; keep it.
+
+**Validator.**
+`/Users/d.smith/MirisProjects/Agent Builder/agent/arch-builds/191c9984-d6c5-468c-a0ad-a95092dbe6d3/normalize_specular_rotation.py`
+mirrors the C++ logic at the USD layer (the C++ runs at the MaterialX-doc
+layer earlier in the pipeline). Running it on the captured
+`complex_export.usda` strips exactly the six known-bogus values and leaves
+every other attribute identical. Karma renders of the prefix and postfix
+USDs are byte-identical (same SHA-256), confirming the fix is a visual
+no-op for the common case — exactly what the BSDF math predicts.
+
+**Retirement condition.** If/when Autodesk fixes `MtlxIOUtil` in a future
+3ds Max release so that the bridge stops emitting the spurious 0.25, the
+normalization pass becomes inert (no node matches the trigger condition).
+The pass can stay in place as a belt-and-suspenders guard for older Max
+installs.
+
+## Expressions with no MaterialX equivalent
+
+| Source (3ds Max) | Why no equivalent | Behavior in current fork |
+| --- | --- | --- |
+| (none catalogued yet) | | |
+
+## Change log
+
+* 2026-06-20 — Initial doc. MAX-MAT-001 specular_rotation default
+  normalization landed.

--- a/src/Tests/Integration/mtlxShaderWriter_test.ms
+++ b/src/Tests/Integration/mtlxShaderWriter_test.ms
@@ -200,13 +200,59 @@ struct mtlx_shader_writer_test
         assert_equal ((shaderPrim.GetAttribute "info:id").Get()) "ND_open_pbr_surface_surfaceshader"
     ),
 
+    -- MAX-MAT-001 regression: PhysicalMaterial export must not carry the
+    -- spurious specular_rotation = 0.25 default that 3ds Max's MtlxIOUtil
+    -- bridge writes on every standard_surface. The post-parse normalization
+    -- in MtlxShaderWriter strips the value when specular_anisotropy is zero
+    -- (or absent), restoring the MaterialX nodedef default.
+    function test_export_physical_material_strips_buggy_specular_rotation = (
+        maxver = maxVersion()
+        -- PhysicalMaterial MaterialX export path is 2025+.
+        if maxver[1] < 26900 then (
+            return 0
+        )
+
+        local teapot001 = teapot name:"teapot001"
+        local mtl1 = PhysicalMaterial()
+        mtl1.name = "matNoAniso"
+        -- Anisotropy explicitly off (this is also the PhysicalMaterial default).
+        mtl1.anisotropy = 0.0
+        teapot001.material = mtl1
+
+        local exportOptions = USDExporter.CreateOptions()
+        exportOptions.FileFormat = #ascii
+        exportOptions.AllMaterialTargets = #("MaterialX")
+
+        local exportPath = output_prefix + "testPhysicalMaterialNoAniso.usda"
+        USDExporter.ExportFile exportPath exportOptions:exportOptions
+        local stage = pyUsd.Stage.Open(exportPath)
+
+        local surfacePrim = stage.GetPrimAtPath("/root/mtl/matNoAniso/matNoAniso")
+        assert_true (surfacePrim.IsValid())
+        assert_true (surfacePrim.IsA(pyShade.Shader))
+        assert_equal ((surfacePrim.GetAttribute "info:id").Get()) "ND_standard_surface_surfaceshader"
+
+        -- The bug: bridge writes specular_rotation = 0.25 on every shader.
+        -- After normalization the input must either be absent (cleanest) or
+        -- explicitly 0.0 (the nodedef default). Both states fix the bug.
+        local surfaceShader = pyShade.Shader(surfacePrim)
+        local rotInput = surfaceShader.GetInput "specular_rotation"
+        if rotInput != undefined then (
+            local rotAttr = rotInput.GetAttr()
+            if rotAttr.HasAuthoredValue() then (
+                assert_equal (rotInput.Get()) 0
+            )
+        )
+    ),
+
     function teardown = (
     ),
 
     Tests = #(
         test_export_physical_material,
         test_export_OpenPBR_material,
-        test_export_material_leading_digit_name
+        test_export_material_leading_digit_name,
+        test_export_physical_material_strips_buggy_specular_rotation
         )
 )
 

--- a/src/translators/MtlxShaderWriter.cpp
+++ b/src/translators/MtlxShaderWriter.cpp
@@ -36,7 +36,78 @@
 
 #include <MaterialXFormat/XmlIo.h>
 
+#include <cmath>
+
 PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// Returns the static float value of a MaterialX input if it is not connected.
+// On a connection (node/nodegraph/output), reports the input as "not statically known".
+bool _TryGetStaticFloat(const MaterialX::InputPtr& input, float& outValue)
+{
+    if (!input) {
+        return false;
+    }
+    if (input->hasNodeName() || input->hasNodeGraphString() || input->hasOutputString()) {
+        return false;
+    }
+    const std::string& valStr = input->getValueString();
+    if (valStr.empty()) {
+        return false;
+    }
+    try {
+        outValue = std::stof(valStr);
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+// MAX-MAT-001 workaround: 3ds Max's MtlxIOUtil bridge emits
+// specular_rotation = 0.25 on every standard_surface node, regardless of the
+// source PhysicalMaterial's anisotropy settings. The MaterialX standard_surface
+// nodedef defaults specular_rotation to 0.0, and the value has no visual effect
+// when specular_anisotropy is zero. Strip the spurious value so the exported
+// USD matches the nodedef default for the common (anisotropy == 0) case.
+// Inputs that are connected, non-zero, or carry a non-0.25 authored value are
+// left untouched.
+void _NormalizeStandardSurfaceSpecularRotation(const MaterialX::DocumentPtr& doc)
+{
+    if (!doc) {
+        return;
+    }
+    for (const auto& node : doc->getNodes("standard_surface")) {
+        auto rotationInput = node->getInput("specular_rotation");
+        if (!rotationInput) {
+            continue;
+        }
+        float rotationValue = 0.f;
+        if (!_TryGetStaticFloat(rotationInput, rotationValue)) {
+            continue;
+        }
+        // Match the buggy 3ds Max hardcoded value (0.25), tolerant of float noise.
+        if (std::fabs(rotationValue - 0.25f) > 1e-6f) {
+            continue;
+        }
+        // Only strip when specular_anisotropy is provably zero (or absent).
+        // If anisotropy is connected, the user may genuinely want a rotation,
+        // so we conservatively keep the input.
+        auto anisotropyInput = node->getInput("specular_anisotropy");
+        if (anisotropyInput) {
+            float anisotropyValue = 0.f;
+            if (!_TryGetStaticFloat(anisotropyInput, anisotropyValue)) {
+                continue;
+            }
+            if (std::fabs(anisotropyValue) > 1e-6f) {
+                continue;
+            }
+        }
+        node->removeInput("specular_rotation");
+    }
+}
+
+} // namespace
 
 bool _IsWellFormedPath(const fs::path& p)
 {
@@ -519,6 +590,8 @@ void MtlxShaderWriter::Write()
         TF_WARN("Error reading MaterialX document: %s", e.what());
         return;
     }
+
+    _NormalizeStandardSurfaceSpecularRotation(mtlxDoc);
 
     // Sanitize the material name using the same logic as with the MaterialX component
     // to match the node name produced by the MaterialX exporter. createValidName


### PR DESCRIPTION
## Summary

3ds Max's `MtlxIOUtil.ExportMtlxString` MaxScript bridge writes `specular_rotation = 0.25` on every `ND_standard_surface_surfaceshader`, regardless of source PhysicalMaterial anisotropy. The MaterialX `standard_surface` nodedef default is **0.0**, and `specular_rotation` is multiplied by `specular_anisotropy` in the BSDF — so when anisotropy is 0 (the universal default case), the value has zero observable effect, but it silently corrupts downstream pipelines that read MaterialX values directly or layer-override anisotropy later.

This PR adds a post-parse normalization step in `MtlxShaderWriter::Write()` that drops `specular_rotation` from `standard_surface` nodes when:

- the value is statically **0.25** (the bug pattern), AND
- `specular_anisotropy` is absent OR statically zero.

Connected anisotropy, any non-`0.25` rotation, or a connected rotation input are all left untouched, so the fix is surgical and does not touch genuinely-authored anisotropic materials.

## Diagnostic finding

- **Fingerprint**: `MAX-MAT-001-specular-rotation-default-0.25`
- **Scope**: 6/6 materials in `samples/complex_export.usda` affected
- **Severity**: medium — semantic correctness; silent regression risk for downstream anisotropy edits

## What's changed

- `src/translators/MtlxShaderWriter.cpp` — adds `_NormalizeStandardSurfaceSpecularRotation`, called immediately after `readFromXmlString`.
- `src/Tests/Integration/mtlxShaderWriter_test.ms` — adds `test_export_physical_material_strips_buggy_specular_rotation`, a regression test that creates a default `PhysicalMaterial`, exports it via MaterialX, and asserts `specular_rotation` is either absent or 0.0.
- `doc/translation-mapping.md` — new tracking doc for 3ds Max -> MaterialX property translation status. MAX-MAT-001 is the first row.
- `doc/changelog.md` — Unreleased entry.

## Validation

3ds Max is Windows-only and this repo builds via Visual Studio (`configure-vsdevcmd.bat`). I cannot build or run the plugin on macOS, so I validated by mirroring the C++ logic in Python at the USD layer (`normalize_specular_rotation.py` in the arch-build dir):

- **Positive corpus** — running the normalizer on `samples/complex_export.usda` strips exactly the 6 known-bogus `specular_rotation = 0.25` lines and changes nothing else (USDA diff = 6 deletions, 0 additions, 0 modifications).
- **Visual no-op** — Karma renders of the pre-fix and post-fix USDs are byte-identical (same SHA-256: `eaf3832840…b8351`). This is the expected outcome: `specular_rotation` * `specular_anisotropy` = 0 when anisotropy is 0, so the lighting integrator never sees the value.
- **Negative test** — a synthetic fixture injects `specular_anisotropy = 0.4` onto one shader. The normalizer correctly preserves `specular_rotation = 0.25` on that shader while still stripping it from the other 5. Confirms the fix is surgical.

## Build / run status

- Build (Visual Studio, Windows): **deferred** — requires a Windows MSBuild environment with the 3ds Max SDK; not available on this Mac.
- MaxScript regression test: **deferred** — requires 3ds Max (Windows-only).
- Logic equivalence: **verified** via Python validator against the captured corpus.

## Status

Opening for review. The C++ change is straightforward and has clear semantics, but a Windows build/test pass is needed before this is merge-ready. The visual evidence and Python-validated post-fix USD strongly suggest the change is correct.