### PR TITLE
Export bones with modifiers

### DIFF
--- a/src/MaxUsd/Builders/USDSceneBuilder.cpp
+++ b/src/MaxUsd/Builders/USDSceneBuilder.cpp
@@ -1567,7 +1567,7 @@ MaxUsd::PrimDefVectorPtr USDSceneBuilder::WriteNodePrims(
     // guides, to avoid them being rendered unless explicitly requested. Geometry set as
     // non-renderable will also be set as guides.
     bool isGuideObject
-        = MaxUsd::IsBoneObject(context.node->EvalWorldState(context.timeConfig.GetStartTime()).obj)
+        = MaxUsd::IsBoneObject(context.node->GetObjectRef()->FindBaseObject())
         || context.node->Renderable() == 0;
 
     if (objectXformRequiredFromConfig || objectXFormRequiredFromInstancing || isGuideObject) {

--- a/src/Tests/Integration/export_skeleton_test.ms
+++ b/src/Tests/Integration/export_skeleton_test.ms
@@ -754,7 +754,50 @@ struct export_skin_test
         )
     ),
 
-    function export_skeleton_no_preserve_meshes = 
+    function export_skeleton_include_all_bones_with_modifier =
+    (
+        resetMaxFileAndSetupUnits()
+
+        newBones = createBonesArray 3
+
+        -- Apply a modifier to one of the bones. This bone isn't referenced by any skin/morpher
+        -- modifier, so it relies solely on the IncludeAllBones option to be exported. Bones with
+        -- modifiers applied to them shouldn't be excluded from the export (see GH issue #45).
+        addModifier newBones[2] (Twist angle:15)
+
+        char = createCharMesh()
+
+        -- the bones aren't being added to the skin modifier
+        sk = skin()
+        addModifier char sk
+
+        -- exporting bones without adding them to the skin modifier
+        local exportPath = output_prefix + "export_skeleton_include_all_bones_with_modifier.usda"
+        local exportOptions = createDefaultOptions()
+        exportOptions.SimplifyBonePaths = false
+        exportOptions.IncludeAllBones = true
+        USDExporter.ExportFile exportPath exportOptions:exportOptions
+
+        local stage = pyUsd.Stage.Open(exportPath)
+        local skelRootPath = "/root"
+        local skelPrim = stage.GetPrimAtPath(skelRootPath + "/Bones")
+        local animPrim = stage.GetPrimAtPath(skelRootPath + "/Bones/Animations")
+
+        assert_true (pyUsd.Prim.IsValid skelPrim) Message: "Skeleton prim should have been created for the bones without skin modifier"
+        assert_true (pyUsd.Prim.IsValid animPrim) Message: "SkelAnimation prim should have been created for the bones without skin modifier"
+
+        local expectedJointsNames = #("/root/Bones/Bone001", "/root/Bones/Bone001/Bone002", "/root/Bones/Bone001/Bone002/Bone003")
+        local skelPrimJointsAttribute = (skelPrim.GetAttribute("joints")).Get()
+        local animPrimJointsAttribute = (animPrim.GetAttribute("joints")).Get()
+        assert_equal 3 skelPrimJointsAttribute.count message:"A bone with a modifier applied to it should still be exported when IncludeAllBones is enabled"
+        assert_equal skelPrimJointsAttribute.count animPrimJointsAttribute.count message:"Animation and Skeleton don't have the same amount of joints exported"
+        for i = 1 to skelPrimJointsAttribute.count do (
+            assert_equal expectedJointsNames[i] skelPrimJointsAttribute[i]
+            assert_equal skelPrimJointsAttribute[i] animPrimJointsAttribute[i] message:("Animation and Skeleton don't match " + skelPrimJointsAttribute[i] + ";" + animPrimJointsAttribute[i])
+        )
+    ),
+
+    function export_skeleton_no_preserve_meshes =
     (
         resetMaxFileAndSetupUnits()
 
@@ -942,6 +985,7 @@ struct export_skin_test
         export_skeleton_without_skin_test,
         export_skeleton_bone_weights_test,
         export_skeleton_include_all_bones,
+        export_skeleton_include_all_bones_with_modifier,
         export_skeleton_no_preserve_meshes,
         bone_instancing_ignored_test,
         export_skin_with_turbosmooth,

--- a/src/translators/SkeletonWriter.cpp
+++ b/src/translators/SkeletonWriter.cpp
@@ -342,8 +342,11 @@ MaxUsdSkeletonWriter::CanExport(INode* node, const MaxUsd::USDSceneBuilderOption
         return ContextSupport::Unsupported;
     }
 
-    // Always export any bone when the include all bones option is on
-    if (exportArgs.GetIncludeAllBones() && MaxUsd::IsBoneObject(node->GetObjectRef())) {
+    // Always export any bone when the include all bones option is on. Look past any modifiers
+    // applied on the bone to find the base object, so that bones with modifiers are still
+    // recognized as bones.
+    if (exportArgs.GetIncludeAllBones()
+        && MaxUsd::IsBoneObject(node->GetObjectRef()->FindBaseObject())) {
         return ContextSupport::Fallback;
     }
 


### PR DESCRIPTION
This change fixes #45 by ensuring that bones with modifiers are exported to USD. Exporting the scene mentionned in #45 now yields 3 bones:

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/47e66059-ffcb-4120-985c-51889c6c87e7" />

Three notes of warning for the reviewers:

1. Claude helped me to submit this PR. This is the first time I'm digging into the 3ds Max C++ API. It looks good to me, but I'm not experienced enough in the 3ds Max to claim to understand all its idiosyncrasies
2. I'm currently running the integration tests like this `uv run .\src\Tests\run_integration_tests.py -m 'C:\Program Files\Autodesk\3ds Max 2027\3dsmax.exe'` *from the dev branch, WITHOUT MY PATCH*, but they have been running for a very long time and seems stuck. Building this repo has not been a smooth ride #48 #49 , no maybe something is wrong in my devenv. I'm submitting this PR anyway in hope that your internal CI/CD will catch potential errors anyway.