### PR TITLE
Ensure all vs2022 versions are found

### DIFF
--- a/build-scripts/configure-vsdevcmd.bat
+++ b/build-scripts/configure-vsdevcmd.bat
@@ -106,7 +106,7 @@ goto :End
 
 :2022
 set VS_VERSION_RANGELO=17.0
-set VS_VERSION_RANGEHI=17.11
+set VS_VERSION_RANGEHI=18.0
 goto :vswhere_vcvarsall
 
 :2019


### PR DESCRIPTION
Set the upper Visual Studio version bound to 18.0 so every VS 2022 versions are found.

Fixes issue https://github.com/Autodesk/3dsmax-usd/issues/49